### PR TITLE
Elasticsearch Gateway settings resulted in no indices being recovered upon restart

### DIFF
--- a/elasticsearch/src/main/java/org/apache/karaf/decanter/elasticsearch/EmbeddedNode.java
+++ b/elasticsearch/src/main/java/org/apache/karaf/decanter/elasticsearch/EmbeddedNode.java
@@ -54,7 +54,7 @@ public class EmbeddedNode {
                 .put("discovery.zen.ping.unicast.enabled", true)
                 .put("discovery.zen.unicast.hosts", "127.0.0.1")
                 .put("network.host", "127.0.0.1")
-                .put("gateway.type", "none")
+                .put("gateway.type", "local")
                 .put("cluster.routing.schedule", "50ms")
                 .put("path.plugins", pluginsFile.getAbsolutePath())
                 .build();


### PR DESCRIPTION
I don't know if this is the best way to raise this issue, but as I don't have a login to the apache Jira...

The current settings for the embedded elasticsearch has a config parameter for gateway of "none".  This means that upon restart of the bundle the previous indices are not recovered and all previous data is lost.  The remedy in this commit is to have a gateway of "local".