### PR TITLE
Karaf name in log collector, and CORS properties for embedded ES v1.4

### DIFF
--- a/collector/log/src/main/java/org/apache/karaf/decanter/collector/log/LogAppender.java
+++ b/collector/log/src/main/java/org/apache/karaf/decanter/collector/log/LogAppender.java
@@ -61,6 +61,7 @@ public class LogAppender implements PaxAppender {
 
         Map<String, Object> data = new HashMap<>();
         data.put("type", "log");
+        data.put("karafName", System.getProperty("karaf.name"));
         data.put("timeStamp", event.getTimeStamp());
         data.put("loggerClass", event.getFQNOfLoggerClass());
         data.put("loggerName", event.getLoggerName());

--- a/elasticsearch/src/main/java/org/apache/karaf/decanter/elasticsearch/EmbeddedNode.java
+++ b/elasticsearch/src/main/java/org/apache/karaf/decanter/elasticsearch/EmbeddedNode.java
@@ -57,6 +57,8 @@ public class EmbeddedNode {
                 .put("gateway.type", "local")
                 .put("cluster.routing.schedule", "50ms")
                 .put("path.plugins", pluginsFile.getAbsolutePath())
+                .put("http.cors.enabled", true)
+                .put("http.cors.allow-origin", "/.*/")
                 .build();
 
         LOGGER.debug("Creating the elasticsearch node");


### PR DESCRIPTION
The karaf name added as a logged attribute ("karafName").

ES 1.4 requires a CORS entry in order for Kibana etc. to connect.