### PR TITLE
KARAF-4594 : Log4JSocketCollector multiple clients

### DIFF
--- a/collector/log4j-socket/src/main/cfg/org.apache.karaf.decanter.collector.log.socket.cfg
+++ b/collector/log4j-socket/src/main/cfg/org.apache.karaf.decanter.collector.log.socket.cfg
@@ -3,3 +3,4 @@
 #
 
 #port=4560
+#workers=10

--- a/collector/log4j-socket/src/test/java/org/apache/karaf/decanter/collector/log/socket/SocketCollectorTest.java
+++ b/collector/log4j-socket/src/test/java/org/apache/karaf/decanter/collector/log/socket/SocketCollectorTest.java
@@ -16,11 +16,58 @@
  */
 package org.apache.karaf.decanter.collector.log.socket;
 
-import org.apache.karaf.decanter.collector.log.socket.SocketCollector;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
-public class SocketCollectorTest  {
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.spi.LoggingEvent;
+import org.apache.log4j.spi.NOPLogger;
+import org.apache.log4j.spi.NOPLoggerRepository;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.ComponentInstance;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventAdmin;
+
+public class SocketCollectorTest {
+
+    private ComponentContext componentContext;
+    private SocketCollector collector;
+    private int port;
+    private EventAdminStub eventAdmin;
+
+    @Before
+    public void setUp() throws IOException {
+        port = SocketUtils.findAvailablePort();
+        eventAdmin = new EventAdminStub();
+        collector = new SocketCollector();
+        collector.setEventAdmin(eventAdmin);
+        componentContext = new ComponentContextStub();
+        componentContext.getProperties().put(SocketCollector.PORT_NAME, String.valueOf(port));
+        componentContext.getProperties().put(SocketCollector.WORKERS_NAME, "1");
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        if (collector != null && collector.isOpen()) {
+            collector.close();
+        }
+    }
 
     @Test
     public void testLoggerName2Topic() {
@@ -28,4 +75,168 @@ public class SocketCollectorTest  {
         Assert.assertEquals("decanter/collect/log/test/Tomcat/localhost", topic);
     }
 
+    /**
+     * Test event handling (1 event)
+     */
+    @Test
+    public void testSocket() throws Exception {
+        activate();
+        sendEventOnSocket(newLoggingEvent("Sample message"));
+        waitUntilEventCountHandled(1);
+        assertEquals("Event(s) should have been correctly handled", 1, eventAdmin.getPostEvents().size());
+    }
+
+    /**
+     * Test event handling with multiple clients
+     */
+    @Test
+    public void testSocketMultipleClients() throws Exception {
+
+        activate();
+
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    sendEventOnSocket(newLoggingEvent("Sample message"));
+                } catch (Throwable e) {
+                    e.printStackTrace();
+                }
+            }
+        };
+
+        // starts 2 client threads
+        Thread thread;
+        thread = new Thread(runnable);
+        thread.start();
+        thread = new Thread(runnable);
+        thread.start();
+
+        waitUntilEventCountHandled(2);
+        assertEquals("Event(s) should have been correctly handled", 2, eventAdmin.getPostEvents().size());
+    }
+
+    private void waitUntilEventCountHandled(int eventCount) throws InterruptedException {
+        long timeout = 20000L;
+        long start = System.currentTimeMillis();
+        boolean hasTimeoutReached = false;
+        do {
+            hasTimeoutReached = ((System.currentTimeMillis() - start) > timeout);
+            Thread.sleep(10L);
+        } while (eventAdmin.getPostEvents().size() < eventCount && hasTimeoutReached == false);
+    }
+
+    private LoggingEvent newLoggingEvent(String message) {
+        return new LoggingEvent(this.getClass().getName(), new NOPLogger(new NOPLoggerRepository(), "NOP"),
+                                System.currentTimeMillis(), Level.INFO, message,
+                                Thread.currentThread().getName(), null, null, null, new Properties());
+    }
+
+    /**
+     * Launches serverSocket on available port
+     * 
+     * @throws InterruptedException
+     */
+    private void activate() throws IOException, InterruptedException {
+        collector.activate(componentContext);
+        Thread.sleep(200L);
+    }
+
+    private void sendEventOnSocket(LoggingEvent event) throws IOException {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress("localhost", port), 5000);
+            try (ObjectOutputStream out = new ObjectOutputStream(socket.getOutputStream())) {
+                out.writeObject(event);
+                out.flush();
+            }
+        }
+    }
+
+    /**
+     * Stub used only for this unit test
+     */
+    private static class ComponentContextStub implements ComponentContext {
+
+        private Dictionary properties = new Hashtable<>();
+
+        @Override
+        public Dictionary getProperties() {
+            return properties;
+        }
+
+        @Override
+        public Object locateService(String name) {
+            throw new NoSuchMethodError("Unimplemented method");
+        }
+
+        @Override
+        public Object locateService(String name, ServiceReference reference) {
+            throw new NoSuchMethodError("Unimplemented method");
+        }
+
+        @Override
+        public Object[] locateServices(String name) {
+            throw new NoSuchMethodError("Unimplemented method");
+        }
+
+        @Override
+        public BundleContext getBundleContext() {
+            throw new NoSuchMethodError("Unimplemented method");
+        }
+
+        @Override
+        public Bundle getUsingBundle() {
+            throw new NoSuchMethodError("Unimplemented method");
+        }
+
+        @Override
+        public ComponentInstance getComponentInstance() {
+            throw new NoSuchMethodError("Unimplemented method");
+        }
+
+        @Override
+        public void enableComponent(String name) {
+            throw new NoSuchMethodError("Unimplemented method");
+        }
+
+        @Override
+        public void disableComponent(String name) {
+            throw new NoSuchMethodError("Unimplemented method");
+        }
+
+        @Override
+        public ServiceReference getServiceReference() {
+            throw new NoSuchMethodError("Unimplemented method");
+        }
+
+    }
+
+    private static class EventAdminStub implements EventAdmin {
+        private List<Event> postEvents = new ArrayList<>();
+        private List<Event> sendEvents = new ArrayList<>();
+
+        @Override
+        public void postEvent(Event event) {
+            postEvents.add(event);
+        }
+
+        @Override
+        public void sendEvent(Event event) {
+            sendEvents.add(event);
+        }
+
+        public List<Event> getPostEvents() {
+            return postEvents;
+        }
+
+        public List<Event> getSendEvents() {
+            return sendEvents;
+        }
+
+        public void reset() {
+            postEvents.clear();
+            sendEvents.clear();
+        }
+
+    }
 }

--- a/collector/log4j-socket/src/test/java/org/apache/karaf/decanter/collector/log/socket/SocketUtils.java
+++ b/collector/log4j-socket/src/test/java/org/apache/karaf/decanter/collector/log/socket/SocketUtils.java
@@ -1,0 +1,51 @@
+package org.apache.karaf.decanter.collector.log.socket;
+
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.util.Random;
+
+import javax.net.ServerSocketFactory;
+
+/**
+ * Utility class to determine if TCP port is available on localhost.
+ * 
+ * @author agonzalez
+ */
+public final class SocketUtils {
+
+    private static final Random random = new Random();
+    public static final int MIN_PORT = 40000;
+    public static final int MAX_PORT = 65535;
+
+    /**
+     * Returns the first available port between {@link #MIN_PORT} and
+     * {@link #MAX_PORT}
+     */
+    public static int findAvailablePort() {
+        int port;
+        do {
+            port = findRandomPort(MIN_PORT, MAX_PORT);
+
+        } while (!isPortAvailable(port));
+        return port;
+    }
+
+    private static boolean isPortAvailable(int port) {
+        try {
+            ServerSocket serverSocker = ServerSocketFactory.getDefault().createServerSocket(port, 1,
+                    InetAddress.getByName("localhost"));
+            serverSocker.close();
+            return true;
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+
+    private static int findRandomPort(int minPort, int maxPort) {
+        if (maxPort < minPort) {
+            throw new IllegalArgumentException("maxPort should be >= minPort");
+        }
+        int portRange = maxPort - minPort + 1;
+        return random.nextInt(portRange) + minPort;
+    }
+}


### PR DESCRIPTION
This commit fixes current SocketCollector limitation : it handled only 1 client
simultaneously.

With the following implementation :

* you configure number of workers
* serverSocket is handled by a master thread
* client sockets are handled by the workers

I've also added some unit tests, but since I'm testing a multi-threaded module results are unpredictable (I've set unit test timeout to 10s so it should be ok to process 1 ou 2 events in most cases).

*A question though*

Log4J 1.x SocketAppender appears to open a socket and keeps it open during the lifetime of the application.

I wonder how we can scale with this append in a real world situation.
