### PR TITLE
KARAF-4850 Be able to specify several object names for the JMX collector

### DIFF
--- a/collector/jmx/pom.xml
+++ b/collector/jmx/pom.xml
@@ -33,6 +33,15 @@
     <packaging>bundle</packaging>
     <name>Apache Karaf :: Decanter :: Collector :: JMX</name>
 
+    <dependencies>
+    	<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>1.10.19</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/collector/jmx/src/main/cfg/org.apache.karaf.decanter.collector.jmx-activemq.cfg
+++ b/collector/jmx/src/main/cfg/org.apache.karaf.decanter.collector.jmx-activemq.cfg
@@ -20,6 +20,12 @@ url=local
 # some MBeans matching the object name filter
 object.name=org.apache.activemq:*
 
+# Several object names can also be specified.
+# What matters is that the property names begin with "object.name".
+#object.name.system=java.lang:*
+#object.name.karaf=org.apache.karaf:type=http,name=*
+#object.name.3=org.apache.activemq:*
+
 # You can add any custom field that the collector will "forward" to the dispatcher
 # For instance:
 #

--- a/collector/jmx/src/main/cfg/org.apache.karaf.decanter.collector.jmx-camel.cfg
+++ b/collector/jmx/src/main/cfg/org.apache.karaf.decanter.collector.jmx-camel.cfg
@@ -20,6 +20,12 @@ url=local
 # some MBeans matching the object name filter
 object.name=org.apache.camel:context=*,type=routes,name=*
 
+# Several object names can also be specified.
+# What matters is that the property names begin with "object.name".
+#object.name.system=java.lang:*
+#object.name.karaf=org.apache.karaf:type=http,name=*
+#object.name.3=org.apache.activemq:*
+
 # You can add any custom field that the collector will "forward" to the dispatcher
 # For instance:
 #

--- a/collector/jmx/src/main/cfg/org.apache.karaf.decanter.collector.jmx-local.cfg
+++ b/collector/jmx/src/main/cfg/org.apache.karaf.decanter.collector.jmx-local.cfg
@@ -20,6 +20,12 @@ url=local
 # some MBeans matching the object name filter
 #object.name=org.apache.camel:context=*,type=routes,name=*
 
+# Several object names can also be specified.
+# What matters is that the property names begin with "object.name".
+#object.name.system=java.lang:*
+#object.name.karaf=org.apache.karaf:type=http,name=*
+#object.name.3=org.apache.activemq:*
+
 # You can add any custom field that the collector will "forward" to the dispatcher
 # For instance:
 #

--- a/collector/jmx/src/test/java/org/apache/karaf/decanter/collector/jmx/TestMapAttribute.java
+++ b/collector/jmx/src/test/java/org/apache/karaf/decanter/collector/jmx/TestMapAttribute.java
@@ -1,7 +1,12 @@
 package org.apache.karaf.decanter.collector.jmx;
 
 import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 
 import javax.management.MBeanServerConnection;
 import javax.management.MalformedObjectNameException;
@@ -9,6 +14,8 @@ import javax.management.ObjectName;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.osgi.service.component.ComponentContext;
 
 public class TestMapAttribute {
 
@@ -23,5 +30,46 @@ public class TestMapAttribute {
         Assert.assertTrue(freeMem instanceof Long);
         Assert.assertTrue((Long)freeMem > 10000);
         System.out.println(data);
+    }
+
+    @Test
+    public void testSingleObjectName() throws Exception {
+    	ComponentContext ctx = Mockito.mock( ComponentContext.class );
+    	Properties props = new Properties();
+    	Mockito.when( ctx.getProperties()).thenReturn( props );
+
+    	props.put( "object.name", "java.lang:*" );
+    	JmxCollector collector = new JmxCollector();
+    	Assert.assertNull( collector.getObjectNames());
+    	collector.activate( ctx );
+
+    	Set<String> objectNames = collector.getObjectNames();
+    	Assert.assertEquals( 1, objectNames.size());
+    	Assert.assertEquals( "java.lang:*", objectNames.iterator().next());
+    }
+
+    @Test
+    public void testSeveralObjectNames() throws Exception {
+    	ComponentContext ctx = Mockito.mock( ComponentContext.class );
+    	Properties props = new Properties();
+    	Mockito.when( ctx.getProperties()).thenReturn( props );
+
+    	props.put( "object.name.system", "java.lang:*" );
+    	props.put( "object.name", "org.something.else:*" );
+    	props.put( "object.name.karaf", "org.apache.karaf:type=http" );
+    	props.put( "object.name.2", "whatever" );
+    	props.put( "object.name-invalid", "not expected" );
+
+    	JmxCollector collector = new JmxCollector();
+    	Assert.assertNull( collector.getObjectNames());
+    	collector.activate( ctx );
+
+    	List<String> objectNames = new ArrayList<>( collector.getObjectNames());
+    	Collections.sort( objectNames );
+    	Assert.assertEquals( 4, objectNames.size());
+    	Assert.assertEquals( "java.lang:*", objectNames.get( 0 ));
+    	Assert.assertEquals( "org.apache.karaf:type=http", objectNames.get( 1 ));
+    	Assert.assertEquals( "org.something.else:*", objectNames.get( 2 ));
+    	Assert.assertEquals( "whatever", objectNames.get( 3 ));
     }
 }

--- a/manual/src/main/asciidoc/user-guide/collectors.adoc
+++ b/manual/src/main/asciidoc/user-guide/collectors.adoc
@@ -206,6 +206,12 @@ url=local
 # Object name filter to use. Instead of harvesting all MBeans, you can select only
 # some MBeans matching the object name filter
 #object.name=org.apache.camel:context=*,type=routes,name=*
+
+# Several object names can also be specified.
+# What matters is that the property names begin with "object.name".
+#object.name.system=java.lang:*
+#object.name.karaf=org.apache.karaf:type=http,name=*
+#object.name.3=org.apache.activemq:*
 ----
 
 This file harvests the data of the local MBeanServer:
@@ -221,7 +227,7 @@ is secured.
 is secured.
 * the `object.name` property is optional. If this property is not specified, the collector will retrieve the attributes
 of all MBeans. You can filter to consider only some MBeans. This property contains the ObjectName filter to retrieve
-the attributes only to some MBeans.
+the attributes only to some MBeans. Several object names can be listed, provided the property prefix is `object.name.`.
 * any other values will be part of the collected data. It means that you can add your own property if you want to add
 additional data, and create queries based on this data.
 


### PR DESCRIPTION
This pull request allows to specify several object names within a same configuration file. It avoids to duplicate the JMX parameters over several files. The implementation is backward compatible, meaning we can still define an object name with...

```
object.name=java.lang:*
```

List of objects names can be defined with the following syntax.

```
object.name.system=java.lang:*
object.name.karaf=org.apache.karaf:type=http,name=*
object.name.3=net.something:*
```

We use **object.name.** as a prefix for properties.
Notations can be mixed.