### PR TITLE
[PROPOSAL] - CustomUnmarshaller

### DIFF
--- a/collector/socket/src/main/cfg/org.apache.karaf.decanter.collector.socket.cfg
+++ b/collector/socket/src/main/cfg/org.apache.karaf.decanter.collector.socket.cfg
@@ -8,3 +8,7 @@
 
 # Protocol tcp(default) or udp
 #protocol=tcp
+
+# Unmarshaller to use
+# Unmarshaller is identified by data format. The default is json, but you can use another unmarshaller
+unmarshaller.target=(dataFormat=json)

--- a/collector/socket/src/main/java/org/apache/karaf/decanter/collector/socket/SocketCollector.java
+++ b/collector/socket/src/main/java/org/apache/karaf/decanter/collector/socket/SocketCollector.java
@@ -60,20 +60,21 @@ public class SocketCollector implements Closeable, Runnable {
     private Dictionary<String, Object> properties;
     private String eventAdminTopic;
     private EventAdmin dispatcher;
-    private Unmarshaller unmarshaller;
+    
+    @Reference
+    public Unmarshaller unmarshaller;
     
     private enum Protocol {
         TCP,
         UDP;
     }
 
-    @SuppressWarnings("unchecked")
     @Activate
     public void activate(ComponentContext context) throws IOException {
         this.properties = context.getProperties();
         int port = Integer.parseInt(getProperty(this.properties, "port", "34343"));
         int workers = Integer.parseInt(getProperty(this.properties, "workers", "10"));
-        
+
         this.protocol = Protocol.valueOf(getProperty(this.properties, "protocol", "tcp").toUpperCase());
         // force TCP protocol if value not in Enum
         if (this.protocol == null) {
@@ -250,10 +251,4 @@ public class SocketCollector implements Closeable, Runnable {
     public void setDispatcher(EventAdmin dispatcher) {
         this.dispatcher = dispatcher;
     }
-
-    @Reference
-    public void setUnmarshaller(Unmarshaller unmarshaller) {
-        this.unmarshaller = unmarshaller;
-    }
-
 }

--- a/manual/src/main/asciidoc/user-guide/collectors.adoc
+++ b/manual/src/main/asciidoc/user-guide/collectors.adoc
@@ -472,11 +472,17 @@ This feature installs a default `etc/org.apache.karaf.decanter.collector.socket.
 
 # Protocol tcp(default) or udp
 #protocol=tcp
+
+# Unmarshaller to use
+# Unmarshaller is identified by data format. The default is json, but you can use another unmarshaller
+unmarshaller.target=(dataFormat=json)
 ----
 
 * the `port` property contains the port number where the network socket collector is listening
 * the `workers` property contains the number of worker thread the socket collector is using for connection
 * the `protocol` property contains the protocol used by the collector for transferring data with the client
+* the `unmarshaller.target` property contains the unmarshaller used by the collector to transform the data
+sended by the client.
 
 ==== JMS
 


### PR DESCRIPTION
CustomUnmarshaller - Provide capability of choose the dataformat for unmarshall data receive by the socket collector.

The CustomUnmarshaller must :
- be deploy as a OSGi bundle
- implements org.apache.karaf.decanter.api.marshaller.Unmarshaller API
- be declared as @Component(immediate = true, property = Marshaller.SERVICE_KEY_DATAFORMAT + "=customDataformat")