### PR TITLE
[KARAF-6242] Improve Split and Regex parser by casting data

### DIFF
--- a/parser/regex/src/main/java/org/apache/karaf/decanter/parser/regex/RegexParser.java
+++ b/parser/regex/src/main/java/org/apache/karaf/decanter/parser/regex/RegexParser.java
@@ -77,6 +77,19 @@ public class RegexParser implements Parser {
             }
             if (matcher.find()) {
                 for (int i = 0; i < matcher.groupCount(); i++) {
+                    try {
+                        data.put(keysArray[i], Integer.parseInt(matcher.group(i + 1)));
+                        continue;
+                    } catch (Exception e) {
+                        // nothing to do
+                    }
+
+                    try {
+                        data.put(keysArray[i], Long.parseLong(matcher.group(i + 1)));
+                        continue;
+                    } catch (Exception e) {
+                        // nothing to do
+                    }
                     data.put(keysArray[i], matcher.group(i + 1));
                 }
             }

--- a/parser/split/src/main/java/org/apache/karaf/decanter/parser/split/SplitParser.java
+++ b/parser/split/src/main/java/org/apache/karaf/decanter/parser/split/SplitParser.java
@@ -72,6 +72,20 @@ public class SplitParser implements Parser {
                 }
             }
             for (int i = 0; i < valuesArray.length; i++) {
+                try {
+                    map.put(keysArray[i], Integer.parseInt(valuesArray[i]));
+                    continue;
+                } catch (Exception e) {
+                    // nothing to do
+                }
+
+                try {
+                    map.put(keysArray[i], Long.parseLong(valuesArray[i]));
+                    continue;
+                } catch (Exception e) {
+                    // nothing to do
+                }
+                // if not integer and long value
                 map.put(keysArray[i], valuesArray[i]);
             }
         }


### PR DESCRIPTION
When parsing data with Split and Regex parser, we don't check if it could be sent as Integer or Long.