### PR TITLE
Log4j Socket collector doesn't start in the container

### DIFF
--- a/collector/log4j-socket/pom.xml
+++ b/collector/log4j-socket/pom.xml
@@ -93,25 +93,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            !com.ibm.uvm.tools,
-                            *
-                        </Import-Package>
-                        <Private-Package>
-                            org.apache.karaf.decanter.collector.log.socket,
-                            org.apache.log4j.spi,
-                            org.apache.log4j.helpers,
-                            org.apache.log4j.or,
-                            org.apache.log4j.pattern
-                        </Private-Package>
-                    </instructions>
-                </configuration>
-            </plugin>
         </plugins>
     </build> 
 </project>


### PR DESCRIPTION
There are duplicate bundle-plugin definitions and you get the error:

Error executing command: Unable to resolve root: missing requirement [root] osgi.identity; osgi.identity=decanter-collector-log-socket; type=karaf.feature; version="[2.3.0.SNAPSHOT,2.3.0.SNAPSHOT]"; filter:="(&(osgi.identity=decanter-collector-log-socket)(type=karaf.feature)(version>=2.3.0.SNAPSHOT)(version<=2.3.0.SNAPSHOT))" [caused by: Unable to resolve decanter-collector-log-socket/2.3.0.SNAPSHOT: missing requirement [decanter-collector-log-socket/2.3.0.SNAPSHOT] osgi.identity; osgi.identity=decanter-collector-log-socket-core; type=karaf.feature [caused by: Unable to resolve decanter-collector-log-socket-core/2.3.0.SNAPSHOT: missing requirement [decanter-collector-log-socket-core/2.3.0.SNAPSHOT] osgi.identity; osgi.identity=org.apache.karaf.decanter.collector.log.socket; type=osgi.bundle; version="[2.3.0.SNAPSHOT,2.3.0.SNAPSHOT]"; resolution:=mandatory [caused by: Unable to resolve org.apache.karaf.decanter.collector.log.socket/2.3.0.SNAPSHOT: missing requirement [org.apache.karaf.decanter.collector.log.socket/2.3.0.SNAPSHOT] osgi.wiring.package; filter:="(osgi.wiring.package=org.apache.karaf.decanter.collector.utils)"]]]

