### PR TITLE
KARAF-6507: Creating optional UUID for dedicated connections of same type (e.g. ActiveMQ)

### DIFF
--- a/alerting/checker/src/main/cfg/org.apache.karaf.decanter.alerting.checker.cfg
+++ b/alerting/checker/src/main/cfg/org.apache.karaf.decanter.alerting.checker.cfg
@@ -26,6 +26,10 @@
 # The format is the following:
 #
 # type.eventProperty.level=check:value
+
+# To set a unique alert identifier, e.g. Name of ActiveMQ
+# type.alertUUID=Name
+
 #
 # type is optional, it's the event type. It allows you filter the check for a given collected data type.
 # eventProperty is the collected event property name.


### PR DESCRIPTION
I've implemented a possible solution to create a unique id of general configured alert configurations.

Hereby I've changed the following items: 
  - added additional comments,
  - added method checkBySeverity to remove code duplication
  - added method buildAlertStoreUK to create a unique id per configuration for alert configurations (if configured).