### PR TITLE
fix batch options, get batch options from config, get tags from confi…

### DIFF
--- a/appender/influxdb/src/main/cfg/org.apache.karaf.decanter.appender.influxdb.cfg
+++ b/appender/influxdb/src/main/cfg/org.apache.karaf.decanter.appender.influxdb.cfg
@@ -32,3 +32,13 @@ url=http://localhost:8086
 
 # InfluxDB database name
 database=decanter
+
+# InfluxDB Batch Options
+# batchActionsLimit=200
+# precision=MILLISECONDS
+# flushDuration=100
+
+# InfluxDB tags to be sent for each point
+# Several tags can also be specified.
+# tag.key1=val1
+# tag.key2=val2


### PR DESCRIPTION
Hi,
I've tried using the influxdb-appender with an apache unomi application and experience a few issues that needed a fix.
fixes:
1. batch options weren't being configured correctly (retention policy and time precision)
2. junk properties in events, null fields, and complex objects caused issues and could not be persisted in influx.
enhancements:
3. overriding default batch options from config.
4. sending tags with metrics, getting tags from config
