### PR TITLE
[KARAF-6981] Use generic version number in examples and annotate the …

### DIFF
--- a/manual/pom.xml
+++ b/manual/pom.xml
@@ -55,6 +55,7 @@
                                 <linkcss>false</linkcss>
                                 <stylesheet>style/apache.css</stylesheet>
                                 <imagesdir>images</imagesdir>
+                                <project-version>${project.version}</project-version>
                             </attributes>
                         </configuration>
                     </execution>

--- a/manual/src/main/asciidoc/user-guide/introduction.adoc
+++ b/manual/src/main/asciidoc/user-guide/introduction.adoc
@@ -32,14 +32,16 @@ Apache Karaf Decanter provides Karaf features for each collector, appender, aler
 The first thing to do is to add the Decanter features repository in Karaf:
 
 ----
-karaf@root()> feature:repo-add mvn:org.apache.karaf.decanter/apache-karaf-decanter/2.0.0/xml/features
+karaf@root()> feature:repo-add mvn:org.apache.karaf.decanter/apache-karaf-decanter/2.x.x/xml/features <1>
 ----
+<1> Substitute the desired version, i.e. {project-version}, for 2.x.x
 
 Or
 
 ----
-karaf@root()> feature:repo-add decanter 2.0.0
+karaf@root()> feature:repo-add decanter 2.x.x <1>
 ----
+<1> Substitute the desired version, i.e. {project-version}, for 2.x.x
 
 Now, you have to install the collectors, appenders, and eventually alerters feature to match your need.
 


### PR DESCRIPTION
…current version

- Use the generic 2.x.x as the Decanter version number in examples
- Pass the project version number into the variable {project-version} for used in the documentation