### PR TITLE
[KARAF-6982] Rename the decanter-appender-file default output file to…

### DIFF
--- a/appender/file/src/main/cfg/org.apache.karaf.decanter.appender.file.cfg
+++ b/appender/file/src/main/cfg/org.apache.karaf.decanter.appender.file.cfg
@@ -22,7 +22,7 @@
 ######################################
 
 # File
-#filename=${karaf.data}/decanter
+#filename=${karaf.data}/decanter/appender.csv
 
 # Marshaller
 marshaller.target=(dataFormat=csv)

--- a/appender/file/src/main/java/org/apache/karaf/decanter/appender/file/FileAppender.java
+++ b/appender/file/src/main/java/org/apache/karaf/decanter/appender/file/FileAppender.java
@@ -58,7 +58,7 @@ public class FileAppender implements EventHandler {
     public void open(Dictionary<String, Object> config) throws Exception {
         this.config = config;
 
-        String filename = (config.get(FILENAME_PROPERTY) != null) ? (String) config.get(FILENAME_PROPERTY) : System.getProperty("karaf.data") + File.separator + "decanter";
+        String filename = (config.get(FILENAME_PROPERTY) != null) ? (String) config.get(FILENAME_PROPERTY) : System.getProperty("karaf.data") + File.separator + "decanter" + File.separator + "appender.csv";
         boolean append = (config.get(APPEND_PROPERTY) != null) ? Boolean.parseBoolean((String) config.get(APPEND_PROPERTY)) : true;
 
         File file = new File(filename);

--- a/itest/src/test/java/org/apache/karaf/decanter/itests/appender/FileAppenderTest.java
+++ b/itest/src/test/java/org/apache/karaf/decanter/itests/appender/FileAppenderTest.java
@@ -70,7 +70,7 @@ public class FileAppenderTest extends KarafTestSupport {
         Thread.sleep(2000);
 
         // read file
-        File file = new File(System.getProperty("karaf.data"), "decanter");
+        File file = new File(System.getProperty("karaf.data") + File.separator + "decanter", "appender.csv");
         StringBuilder builder = new StringBuilder();
         try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
             builder.append(reader.readLine()).append("\n");

--- a/manual/src/main/asciidoc/user-guide/appenders.adoc
+++ b/manual/src/main/asciidoc/user-guide/appenders.adoc
@@ -53,8 +53,11 @@ The `decanter-appender-file` feature installs the file appender:
 karaf@root()> feature:install decanter-appender-file
 ----
 
-By default, the file appender stores the collected data in `${karaf.data}/decanter` file. You can change the file where to store the data
+By default, the file appender stores the collected data in `${karaf.data}/decanter/appender.csv` file. You can change the file where to store the data
 using the `filename` property in `etc/org.apache.karaf.decanter.appender.file.cfg` configuration file.
+
+NOTE: The default file changed from `${karaf.data}/decanter` to `${karaf.data}/decanter/appender.csv` in verson 2.7.0 due to a
+conflict with the Alerting Service.
 
 You can also change the marshaller to use. By default, the marshaller used is the CSV one. But you can switch to the JSON one
 using the `marshaller.target` property in `etc/org.apache.karaf.decanter.appender.file.cfg` configuration file.


### PR DESCRIPTION
… decanter/appender.csv

The file is renamed to avoid a conflict with decanter-alerting.  A note in the documentation
inclues both the new and old defaults.