### PR TITLE
[KARAF-7000] Add System-Wide CPU Load to the oshi collector

### DIFF
--- a/collector/oshi/src/main/java/org/apache/karaf/decanter/collector/oshi/OshiCollector.java
+++ b/collector/oshi/src/main/java/org/apache/karaf/decanter/collector/oshi/OshiCollector.java
@@ -51,6 +51,8 @@ public class OshiCollector implements Runnable {
 
     private Dictionary<String, Object> properties;
 
+    long[] lastSystemCpuLoadTicks = null;
+
     @Activate
     public void activate(ComponentContext componentContext) {
         activate(componentContext.getProperties());
@@ -58,6 +60,7 @@ public class OshiCollector implements Runnable {
 
     public void activate(Dictionary<String, Object> properties) {
         this.properties = properties;
+        this.lastSystemCpuLoadTicks = null;
     }
 
     @Override
@@ -110,6 +113,8 @@ public class OshiCollector implements Runnable {
                 data.put("processor.interrupts", hardwareAbstractionLayer.getProcessor().getInterrupts());
                 data.put("processor.logicalProcessorCount", hardwareAbstractionLayer.getProcessor().getLogicalProcessorCount());
                 data.put("processor.maxFreq", hardwareAbstractionLayer.getProcessor().getMaxFreq());
+		data.put("processor.systemCpuLoadBetweenTicks", lastSystemCpuLoadTicks != null ? hardwareAbstractionLayer.getProcessor().getSystemCpuLoadBetweenTicks(lastSystemCpuLoadTicks) : null);
+                lastSystemCpuLoadTicks = hardwareAbstractionLayer.getProcessor().getSystemCpuLoadTicks();
                 boolean processorsLogical = properties.get("processors.logical") != null ? Boolean.parseBoolean(properties.get("processors.logical").toString()) : true;
                 if (processorsLogical) {
                     int i = 0;

--- a/collector/oshi/src/main/java/org/apache/karaf/decanter/collector/oshi/OshiCollector.java
+++ b/collector/oshi/src/main/java/org/apache/karaf/decanter/collector/oshi/OshiCollector.java
@@ -113,7 +113,7 @@ public class OshiCollector implements Runnable {
                 data.put("processor.interrupts", hardwareAbstractionLayer.getProcessor().getInterrupts());
                 data.put("processor.logicalProcessorCount", hardwareAbstractionLayer.getProcessor().getLogicalProcessorCount());
                 data.put("processor.maxFreq", hardwareAbstractionLayer.getProcessor().getMaxFreq());
-		data.put("processor.systemCpuLoadBetweenTicks", lastSystemCpuLoadTicks != null ? hardwareAbstractionLayer.getProcessor().getSystemCpuLoadBetweenTicks(lastSystemCpuLoadTicks) : null);
+                data.put("processor.systemCpuLoadBetweenTicks", lastSystemCpuLoadTicks != null ? hardwareAbstractionLayer.getProcessor().getSystemCpuLoadBetweenTicks(lastSystemCpuLoadTicks) : null);
                 lastSystemCpuLoadTicks = hardwareAbstractionLayer.getProcessor().getSystemCpuLoadTicks();
                 boolean processorsLogical = properties.get("processors.logical") != null ? Boolean.parseBoolean(properties.get("processors.logical").toString()) : true;
                 if (processorsLogical) {

--- a/collector/oshi/src/test/java/org/apache/karaf/decanter/collector/oshi/OshiCollectorTest.java
+++ b/collector/oshi/src/test/java/org/apache/karaf/decanter/collector/oshi/OshiCollectorTest.java
@@ -48,7 +48,7 @@ public class OshiCollectorTest {
     }
 
    /**
-    * Verify the SYSTEM_CPU_LOAD_PROPERY is null on the initial collector run
+    * Verify the SYSTEM_CPU_LOAD_PROPERTY is null on the initial collector run
     * and not null on subsequent collector runs.
     */
    @Test

--- a/collector/oshi/src/test/java/org/apache/karaf/decanter/collector/oshi/OshiCollectorTest.java
+++ b/collector/oshi/src/test/java/org/apache/karaf/decanter/collector/oshi/OshiCollectorTest.java
@@ -27,6 +27,8 @@ import java.util.List;
 
 public class OshiCollectorTest {
 
+    static final String SYSTEM_CPU_LOAD_PROPERTY = "processor.systemCpuLoadBetweenTicks";
+
     @Test
     public void test() throws Exception {
         DispatcherMock dispatcherMock = new DispatcherMock();
@@ -43,6 +45,29 @@ public class OshiCollectorTest {
         for (String property : event.getPropertyNames()) {
             System.out.println(property + ":" + event.getProperty(property));
         }
+    }
+
+   /**
+    * Verify the SYSTEM_CPU_LOAD_PROPERY is null on the initial collector run
+    * and not null on subsequent collector runs.
+    */
+   @Test
+   public void testSystemCpuLoad() throws Exception {
+        DispatcherMock dispatcherMock = new DispatcherMock();
+
+        OshiCollector collector = new OshiCollector();
+        collector.setDispatcher(dispatcherMock);
+        collector.activate(new Hashtable<>());
+
+        collector.run();
+        collector.run();
+
+        Assert.assertEquals(2, dispatcherMock.postedEvents.size());
+        Event firstEvent = dispatcherMock.postedEvents.get(0);
+        Assert.assertNull("Initial systemCpuLoadBetweenTicks is null", firstEvent.getProperty(SYSTEM_CPU_LOAD_PROPERTY));
+        Event secondEvent = dispatcherMock.postedEvents.get(1);
+        Assert.assertNotNull("Second systemCpuLoadBetweenTicks is not null", secondEvent.getProperty(SYSTEM_CPU_LOAD_PROPERTY));
+        System.out.println(SYSTEM_CPU_LOAD_PROPERTY + ":" + secondEvent.getProperty(SYSTEM_CPU_LOAD_PROPERTY));
     }
 
     class DispatcherMock implements EventAdmin {


### PR DESCRIPTION
The value is added as property processor.systemCpuLoadBetweenTicks.  On first collection run
the property value is null.  Subsequent collection runs the property value is between 0 and 1 (100%).