### PR TITLE
[KARAF-7257] Make inclusion of history configurable

### DIFF
--- a/collector/camel/src/main/java/org/apache/karaf/decanter/collector/camel/DecanterEventNotifier.java
+++ b/collector/camel/src/main/java/org/apache/karaf/decanter/collector/camel/DecanterEventNotifier.java
@@ -78,6 +78,10 @@ public class DecanterEventNotifier extends EventNotifierSupport {
     public void setIncludeProperties(boolean includeProperties) {
         dextender.setIncludeProperties(includeProperties);
     }
+
+    public void setIncludeHistory(boolean includeHistory) {
+        dextender.setIncludeHistory(includeHistory);
+    }
     
     private boolean isIgnored(CamelEvent event) {
         if (isIgnoredBySourceType(event)) {

--- a/collector/camel/src/main/java/org/apache/karaf/decanter/collector/camel/DecanterInterceptStrategy.java
+++ b/collector/camel/src/main/java/org/apache/karaf/decanter/collector/camel/DecanterInterceptStrategy.java
@@ -109,4 +109,8 @@ public class DecanterInterceptStrategy implements InterceptStrategy {
         dextender.setIncludeProperties(includeProperties);
     }
 
+    public void setIncludeHistory(boolean includeHistory) {
+        dextender.setIncludeHistory(includeHistory);
+    }
+
 }


### PR DESCRIPTION
- includeHistory propery makes inclusion of history configurable
- history stored as list within property "history" in the data object like headers, etc.