### PR TITLE
Fix concurrent access to principals Set

### DIFF
--- a/collector/eventadmin/src/main/java/org/apache/karaf/decanter/collector/eventadmin/EventCollector.java
+++ b/collector/eventadmin/src/main/java/org/apache/karaf/decanter/collector/eventadmin/EventCollector.java
@@ -81,11 +81,14 @@ public class EventCollector implements EventHandler {
     public Map<String, String> convertSubject(Subject subject) {
         Map<String, String> map = new HashMap<String, String>();
         Set<Principal> principals = subject.getPrincipals();
-        for (Principal principal : principals) {
-            if (map.get(principal.getClass().getSimpleName()) != null) {
-                map.put(principal.getClass().getSimpleName(), map.get(principal.getClass().getSimpleName()) + "," + principal.getName());
-            } else {
-                map.put(principal.getClass().getSimpleName(), principal.getName());
+        synchronized (principals) {
+            for (Principal principal : principals) {
+                if (map.get(principal.getClass().getSimpleName()) != null) {
+                    map.put(principal.getClass().getSimpleName(),
+                            map.get(principal.getClass().getSimpleName()) + "," + principal.getName());
+                } else {
+                    map.put(principal.getClass().getSimpleName(), principal.getName());
+                }
             }
         }
         return map;


### PR DESCRIPTION
`subject.getPrincipals()` returns a synchronized SecureSet but the iterator in `principals` must be protected by a synchronization on the `Set` otherwise, if the Set is  modified during iteration, it can lead to this exception : 

```
java.util.ConcurrentModificationException: null
    at java.util.LinkedList$ListItr.checkForComodification(LinkedList.java:970) ~[?:?]
    at java.util.LinkedList$ListItr.next(LinkedList.java:892) ~[?:?]
    at javax.security.auth.Subject$SecureSet$1.next(Subject.java:1082) ~[?:?]
    at org.apache.karaf.decanter.collector.eventadmin.EventCollector.convertSubject(EventCollector.java:84) ~[?:?]
    at org.apache.karaf.decanter.collector.eventadmin.EventCollector.handleEvent(EventCollector.java:64) ~[?:?]
    at org.apache.felix.eventadmin.impl.handler.EventHandlerProxy.sendEvent(EventHandlerProxy.java:432) ~[?:?]
    at org.apache.felix.eventadmin.impl.tasks.HandlerTask.runWithoutDenylistTiming(HandlerTask.java:82) ~[?:?]
    at org.apache.felix.eventadmin.impl.tasks.SyncDeliverTasks.execute(SyncDeliverTasks.java:107) ~[?:?]
    at org.apache.felix.eventadmin.impl.tasks.AsyncDeliverTasks$TaskExecuter.run(AsyncDeliverTasks.java:167) ~[?:?]
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
    at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
    at java.lang.Thread.run(Thread.java:829) ~[?:?]

```
One way to cause the problem is to activate the event monitoring and webconsole and call repeatedly the webconsole

```
for i in {1..100}; do (curl -u karaf:karaf http://localhost:8040/system/console/bundles ) && (curl -u tadmin:tadmin http://localhost:8040/system/console/bundles ) done 
```